### PR TITLE
Adjusting structure to be bundler friendly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dice.gemspec
 gemspec
-
-gem 'minitest'

--- a/dice.gemspec
+++ b/dice.gemspec
@@ -15,5 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Dice::VERSION
   gem.requirements  << 'Treetop version 1.4 or later.'
-  gem.add_dependency "treetop"
+  gem.add_dependency "treetop", ">= 1.4"
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "minitest"
 end

--- a/lib/dice/version.rb
+++ b/lib/dice/version.rb
@@ -1,3 +1,3 @@
-module Dice
+class Dice
   VERSION = "1.0.1"
 end

--- a/test/dice_parser_test.rb
+++ b/test/dice_parser_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'dice'
+require File.expand_path('../test_helper', __FILE__)
 
 class DiceParserTest < MiniTest::Test
 

--- a/test/dice_test.rb
+++ b/test/dice_test.rb
@@ -1,6 +1,4 @@
-require 'minitest/autorun'
-require 'treetop'
-require 'dice'
+require File.expand_path('../test_helper', __FILE__)
 
 class DiceTest < MiniTest::Test
   def test_new_assigns_the_dice_string

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+require "bundler/setup"
+require 'minitest/autorun'
+require 'treetop'
+require 'dice'


### PR DESCRIPTION
Prior to this commit if I ran `bundle exec rake` I got the following
error:

```console
bundler: failed to load command: rake
Gem::Exception: can't find executable rake for gem rake. rake is not
  currently included in the bundle, perhaps you meant to add it to your
  Gemfile?
```

Once I added rake to the gemspec, I began encountering additional errors
related to path and a constant being declared as both a `module` and
a `class`.

This is the minimum to tidy that up.